### PR TITLE
Include feature names in dump, if present

### DIFF
--- a/lib/xgboost/ffi.rb
+++ b/lib/xgboost/ffi.rb
@@ -31,7 +31,7 @@ module XGBoost
     attach_function :XGBoosterPredict, %i[pointer pointer int int int pointer pointer], :int
     attach_function :XGBoosterLoadModel, %i[pointer string], :int
     attach_function :XGBoosterSaveModel, %i[pointer string], :int
-    attach_function :XGBoosterDumpModelEx, %i[pointer string int string pointer pointer], :int
+    attach_function :XGBoosterDumpModelExWithFeatures, %i[pointer int pointer pointer int string pointer pointer], :int
     attach_function :XGBoosterGetAttr, %i[pointer pointer pointer pointer], :int
     attach_function :XGBoosterSetAttr, %i[pointer pointer pointer], :int
     attach_function :XGBoosterGetAttrNames, %i[pointer pointer pointer], :int

--- a/test/booster_test.rb
+++ b/test/booster_test.rb
@@ -1,12 +1,19 @@
 require_relative "test_helper"
 
 class BoosterTest < Minitest::Test
-  def text_dump_text
-    assert booster.dump
+  def test_dump_text
+    assert_match(/0:\[f5</, booster.dump.join)
+    assert_match(/0:\[feat5</, booster_with_feature_names.dump.join)
   end
 
   def test_dump_json
-    assert JSON.parse(booster.dump(dump_format: "json").first)
+    booster_dump = booster.dump(dump_format: "json").first
+    assert JSON.parse(booster_dump)
+    assert_equal 5, JSON.parse(booster_dump).fetch("split")
+
+    feature_booster_dump = booster_with_feature_names.dump(dump_format: "json").first
+    assert JSON.parse(feature_booster_dump)
+    assert_equal "feat5", JSON.parse(feature_booster_dump).fetch("split")
   end
 
   def test_dump_model_text
@@ -54,7 +61,17 @@ class BoosterTest < Minitest::Test
 
   private
 
+  def load_booster
+    XGBoost::Booster.new(model_file: "test/support/boston.model")
+  end
+
   def booster
-    @booster ||= XGBoost::Booster.new(model_file: "test/support/boston.model")
+    @booster ||= load_booster
+  end
+
+  def booster_with_feature_names
+    @booster_with_feature_names ||= load_booster.tap do |booster|
+      booster.feature_names = (0...13).map { |idx| "feat#{idx}" }
+    end
   end
 end


### PR DESCRIPTION
This changes the output of

```ruby
x = [[1, 5], [2, 2], [2, 3], [3, 4]]
y = [1, 0, 1, 0]
dtrain = XGBoost::DMatrix.new(x, label: y)
booster = XGBoost.train({ objective: "reg:squarederror" }, dtrain)

booster.feature_names = %w[first_feature second_feature]
puts booster.dump.first
```
From:
```
0:[f0<2.5] yes=1,no=2,missing=1
	1:[f1<2.5] yes=3,no=4,missing=3
		3:leaf=-0.075000003
		4:leaf=0.100000009
	2:leaf=-0.075000003
```
To:
```
0:[first_feature<2.5] yes=1,no=2,missing=1
	1:[second_feature<2.5] yes=3,no=4,missing=3
		3:leaf=-0.075000003
		4:leaf=0.100000009
	2:leaf=-0.075000003
```